### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command-Line Argument/Option Injection in xattr

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+## 2026-03-24 - [HIGH] Fix Command-Line Argument/Option Injection
+**Vulnerability:** The application executed the `xattr` command via `subprocess.run` passing a variable file path (`["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)]`). If the file path started with a `-`, it could be interpreted as an option by the `xattr` command, leading to Command-Line Argument/Option Injection (CWE-88).
+**Learning:** Any variable input to a command execution that could start with a dash (`-`) might be interpreted as an option, potentially altering the command's behavior or introducing security vulnerabilities, even if shell execution is disabled (`shell=False`).
+**Prevention:** Always use `--` to signify the end of command options before passing any variable input (especially paths or filenames) to subprocess commands. For example: `["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)]`.

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command-Line Argument/Option Injection (CWE-88) in `app/services/criteria_matcher.py`. The `subprocess.run` call for `xattr` did not use `--` to delimit command options before passing the variable `file_path`. If an attacker or user created a file starting with `-` (e.g., `-h` or `-s`), it could be parsed as a command option, leading to unexpected behavior or potential exploitation.
🎯 Impact: Unexpected command execution behavior or failure to retrieve macOS extended attributes on maliciously named files.
🔧 Fix: Inserted the POSIX standard `--` delimiter immediately before the `str(file_path)` argument in the subprocess call to force the command to treat the argument strictly as a file path.
✅ Verification: Ran the full test suite and confirmed no regressions in `test_criteria_matcher.py` or other tests. Verified formatting and linting rules. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15089893011634432083](https://jules.google.com/task/15089893011634432083) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes - Version 0.0.76

### Security Updates

- **[HIGH] Fixed Command-Line Argument/Option Injection (CWE-88) in xattr handling**: The application now uses the POSIX `--` delimiter before passing file paths to the `xattr` command via `subprocess.run`. This prevents file paths beginning with `-` (e.g., `-h`, `-s`) from being incorrectly interpreted as command options, eliminating a potential argument injection vector on macOS systems.

### Changes Summary

| Component | Type | Description |
|-----------|------|-------------|
| `app/services/criteria_matcher.py` | Security Fix | Added `--` separator before file path argument in xattr subprocess call |
| `.jules/sentinel.md` | Documentation | Documented HIGH severity CWE-88 vulnerability and prevention pattern |
| `VERSION` | Version Bump | Updated from 0.0.75 to 0.0.76 |

### Version
**0.0.76** (bumped from 0.0.75)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->