### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection in xattr call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+## 2026-04-09 - [HIGH] Fix Command-Line Argument/Option Injection
+**Vulnerability:** The application used `subprocess.run` to call `xattr` with a user-controlled file path (`["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)]`). If the file path started with a dash (e.g., `-h`), the `xattr` command would interpret it as an option instead of a file path, potentially leading to command-line argument injection or unexpected behavior.
+**Learning:** When passing untrusted or variable file paths to external commands via `subprocess.run`, tools that accept options can be tricked if the file path begins with `-`.
+**Prevention:** Always insert `--` before the file path argument in `subprocess.run` commands (e.g., `["xattr", "-p", "prop", "--", str(file_path)]`) to explicitly signify the end of options and prevent Command-Line Argument Injection (CWE-88).

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection in xattr call

**Severity:** HIGH
**Vulnerability:** The `subprocess.run` call for `xattr` in `app/services/criteria_matcher.py` passed the user-controlled `file_path` directly to the command arguments. If a file path started with a dash (e.g., `-h`), it would be interpreted as a command-line option rather than a file path, leading to Command-Line Argument Injection (CWE-88).
**Impact:** A local or remote attacker who can create files starting with `-` could trick the `xattr` utility into executing unintended options or flags, potentially causing unexpected behavior, application crashes, or evasion of intended logic.
**Fix:** Explicitly added `--` to the argument list prior to the file path. This POSIX standard explicitly tells `xattr` (and Python's underlying arg parsing mechanism) to stop parsing options and treat everything following as positional arguments (file paths).
**Verification:** Ran the test suite to ensure the modified `subprocess.run` command still correctly executes `xattr` against standard files without regression.

---
*PR created automatically by Jules for task [6902174599665054774](https://jules.google.com/task/6902174599665054774) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Security Fixes
- **[HIGH] Fix Command-Line Argument Injection in xattr Call (CWE-88)**: Resolved a command-line argument injection vulnerability in `app/services/criteria_matcher.py` where user-controlled file paths passed to the `xattr` utility could be interpreted as options if they started with a dash. Added POSIX `--` argument separator before file paths in subprocess invocations to explicitly terminate option parsing and prevent argument injection.

### Documentation
- Updated `.jules/sentinel.md` with security vulnerability tracking entry documenting the CWE-88 fix and prevention guidance.

## Changes Summary

| Component | Type | Details |
|-----------|------|---------|
| `app/services/criteria_matcher.py` | Security Fix | Added `--` separator in xattr subprocess call (line 364) |
| `.jules/sentinel.md` | Documentation | Added 2026-04-09 [HIGH] vulnerability entry for CWE-88 |
| `VERSION` | Version Bump | `0.0.75` → (no change required for patch-level security fix) |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->