### PR TITLE
Add Dry Run Mode, Cancel Scan, and Criteria Clarification

### DIFF
--- a/static/js/files.js
+++ b/static/js/files.js
@@ -115,10 +115,14 @@ function dateCellRenderer(params) {
 function statusCellRenderer(params) {
     const file = params.data;
     let statusBadgeClass = 'bg-secondary';
+    let statusText = file.status;
     if (file.status === 'active') {
         statusBadgeClass = 'bg-success';
     } else if (file.status === 'migrating') {
         statusBadgeClass = 'bg-warning text-dark';
+    } else if (file.status === 'dry_run') {
+        statusBadgeClass = 'bg-info text-dark';
+        statusText = 'dry_run (to move)';
     } else if (file.status === 'missing' || file.status === 'deleted') {
         statusBadgeClass = 'bg-danger';
     }
@@ -127,7 +131,7 @@ function statusCellRenderer(params) {
         ? '<i class="bi bi-pin-fill text-secondary me-1" title="File is pinned"></i>'
         : '';
 
-    return `${pinIndicator}<span class="badge ${statusBadgeClass}">${escapeHtml(file.status)}</span>`;
+    return `${pinIndicator}<span class="badge ${statusBadgeClass}">${escapeHtml(statusText)}</span>`;
 }
 
 function tagsCellRenderer(params) {

--- a/static/js/paths.js
+++ b/static/js/paths.js
@@ -685,6 +685,14 @@ function startProgressPolling(pathId) {
         stopBtn.onclick = () => stopScan(pathId);
     }
 
+    const stopBtnHeader = document.getElementById('stop-scan-btn-header');
+    if (stopBtnHeader) {
+        stopBtnHeader.style.display = '';
+        stopBtnHeader.disabled = false;
+        stopBtnHeader.innerHTML = '<i class="bi bi-stop-circle"></i> Stop Scan';
+        stopBtnHeader.onclick = () => stopScan(pathId);
+    }
+
     // Clear any existing interval
     if (progressPollingInterval) {
         clearInterval(progressPollingInterval);
@@ -703,6 +711,11 @@ async function stopScan(pathId) {
         stopBtn.disabled = true;
         stopBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Stopping...';
     }
+    const stopBtnHeader = document.getElementById('stop-scan-btn-header');
+    if (stopBtnHeader) {
+        stopBtnHeader.disabled = true;
+        stopBtnHeader.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Stopping...';
+    }
 
     try {
         const response = await authenticatedFetch(`${API_BASE_URL}/paths/${pathId}/scan/stop`, {
@@ -718,6 +731,10 @@ async function stopScan(pathId) {
                 stopBtn.disabled = false;
                 stopBtn.innerHTML = '<i class="bi bi-stop-circle"></i> Stop Scan';
             }
+            if (stopBtnHeader) {
+                stopBtnHeader.disabled = false;
+                stopBtnHeader.innerHTML = '<i class="bi bi-stop-circle"></i> Stop Scan';
+            }
         }
     } catch (error) {
         console.error('Error stopping scan:', error);
@@ -725,6 +742,10 @@ async function stopScan(pathId) {
         if (stopBtn) {
             stopBtn.disabled = false;
             stopBtn.innerHTML = '<i class="bi bi-stop-circle"></i> Stop Scan';
+        }
+        if (stopBtnHeader) {
+            stopBtnHeader.disabled = false;
+            stopBtnHeader.innerHTML = '<i class="bi bi-stop-circle"></i> Stop Scan';
         }
     }
 }
@@ -755,6 +776,10 @@ async function pollProgress(pathId) {
             const stopBtn = document.getElementById('stop-scan-btn');
             if (stopBtn) {
                 stopBtn.style.display = 'none';
+            }
+            const stopBtnHeader = document.getElementById('stop-scan-btn-header');
+            if (stopBtnHeader) {
+                stopBtnHeader.style.display = 'none';
             }
 
             // Hide progress after a delay

--- a/templates/files.html
+++ b/templates/files.html
@@ -77,7 +77,7 @@
 <!-- Search and Filters -->
 <section class="panel-section mb-3">
 <div class="row g-3 filters-row">
-    <div class="col-12 col-md-6 mb-2 mb-md-0">
+    <div class="col-12 col-md-4 mb-2 mb-md-0">
         <div class="input-group">
             <span class="input-group-text"><i class="bi bi-search"></i></span>
             <input type="text" class="form-control" id="search_input" placeholder="Search file paths..."
@@ -92,7 +92,7 @@
             </button>
         </div>
     </div>
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md-2">
         <div class="input-group">
             <label class="input-group-text d-none d-sm-flex" for="path_id_filter">Path:</label>
             <select class="form-select" id="path_id_filter" aria-label="Filter by path">
@@ -107,6 +107,18 @@
                 <option value="">All</option>
                 <option value="hot">Hot</option>
                 <option value="cold">Cold</option>
+            </select>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="input-group">
+            <label class="input-group-text d-none d-sm-flex" for="status_filter">Status:</label>
+            <select class="form-select" id="status_filter" aria-label="Filter by status">
+                <option value="">All</option>
+                <option value="active">Active</option>
+                <option value="dry_run">Dry Run</option>
+                <option value="migrating">Migrating</option>
+                <option value="missing">Missing/Deleted</option>
             </select>
         </div>
     </div>

--- a/templates/paths/detail.html
+++ b/templates/paths/detail.html
@@ -26,7 +26,7 @@
                             <button type="button" id="scan-path-btn" class="btn btn-info btn-sm">
                                 <i class="bi bi-arrow-repeat"></i><span class="d-none d-sm-inline"> Scan</span>
                             </button>
-                            <button type="button" id="stop-scan-btn" class="btn btn-warning btn-sm" style="display: none;">
+                            <button type="button" id="stop-scan-btn-header" class="btn btn-warning btn-sm" style="display: none;">
                                 <i class="bi bi-stop-circle"></i><span class="d-none d-sm-inline"> Stop</span>
                             </button>
                         </div>

--- a/templates/paths/detail.html
+++ b/templates/paths/detail.html
@@ -26,6 +26,9 @@
                             <button type="button" id="scan-path-btn" class="btn btn-info btn-sm">
                                 <i class="bi bi-arrow-repeat"></i><span class="d-none d-sm-inline"> Scan</span>
                             </button>
+                            <button type="button" id="stop-scan-btn" class="btn btn-warning btn-sm" style="display: none;">
+                                <i class="bi bi-stop-circle"></i><span class="d-none d-sm-inline"> Stop</span>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/templates/paths/form.html
+++ b/templates/paths/form.html
@@ -97,6 +97,19 @@
                                 </small>
                             </div>
 
+                            <div class="mb-4">
+                                <div class="form-check form-switch mt-2">
+                                    <input class="form-check-input" type="checkbox" id="dry_run" name="dry_run">
+                                    <label class="form-check-label" for="dry_run">
+                                        Dry Run Mode
+                                    </label>
+                                </div>
+                                <small class="form-text text-muted">
+                                    <i class="bi bi-info-circle"></i> When enabled, files matching the criteria will be marked as "dry_run (to move)" in the database but will not actually be moved to cold storage.
+                                    This allows you to test your criteria safely.
+                                </small>
+                            </div>
+
                             <div class="d-flex justify-content-between">
                                 <a href="/paths" class="btn btn-secondary">Cancel</a>
                                 <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
Adds the requested features:
1. Clarification text on the Criteria form explaining files move from Hot to Cold storage.
2. Dry Run mode on Paths to test criteria without moving files.
3. Stop Scan button on the Path details page to cancel in-progress scans.

---
*PR created automatically by Jules for task [14465363242758403471](https://jules.google.com/task/14465363242758403471) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release Notes - File Fridge v0.0.76

## Features Added
- Dry Run Mode: checkbox on Path configuration to test criteria safely — matching files are marked "dry_run (to move)" without moving to cold storage.
- Scan Cancel: "Stop Scan" button on Path details page to cancel in-progress scans.
- File Status Filter: new "Status" filter on Files list (All, active, dry_run, migrating, missing).
- Enhanced File Status Display: renders dry-run files as "dry_run (to move)" with a distinct badge.

## Features Updated

| Feature | Type | Description |
|---------|------|-------------|
| Path Configuration | Enhancement | Added Dry Run Mode toggle with explanatory help text. |
| Path Details Page | Enhancement | Added header Stop Scan button and integrated stop behavior into scan lifecycle. |
| Files List Page | Enhancement | Adjusted filter layout and added Status dropdown; status rendering updated to show dry-run label. |
| Scan Progress / Stop Logic | Enhancement | Start/stop polling updated to show/hide and enable/disable header stop control; stop request shows "Stopping..." state and restores on completion. |
| UI Status Rendering | Enhancement | statusCellRenderer supports `dry_run` status and returns overridden badge text. |

## Version Update
- VERSION updated: 0.0.75 → 0.0.76
<!-- end of auto-generated comment: release notes by coderabbit.ai -->