### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command-Line Argument Injection in subprocess call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+
+## 2026-04-14 - [CRITICAL] Fix Command-Line Argument Injection in subprocess call
+**Vulnerability:** The `CriteriaMatcher._get_macos_last_open` function called `xattr` via `subprocess.run` passing `str(file_path)` directly after `-p` option without a `--` separator. This allows Command-Line Argument/Option Injection (CWE-88) if a user-controlled file path starts with `-`, potentially executing arbitrary options.
+**Learning:** Whenever using `subprocess.run` (or similar functions) to invoke command-line utilities with file paths or user input that might start with a dash (`-`), the `--` separator must be used to unambiguously denote the end of command options.
+**Prevention:** Always insert `--` before the file path argument in `subprocess` calls (e.g., `["command", "option", "--", str(file_path)]`).

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The application invoked `xattr` via `subprocess.run` to read macOS extended attributes but failed to isolate command flags from the file path. This exposed a Command-Line Argument Injection (CWE-88) vulnerability if a file path started with `-`.
🎯 **Impact**: If an attacker could control file names starting with a hyphen `-`, they could potentially inject arbitrary options into the `xattr` command.
🔧 **Fix**: Modified the `subprocess.run` call in `CriteriaMatcher._get_macos_last_open` to include the `--` argument separator. This ensures any subsequent tokens are parsed strictly as file paths, negating any injected options.
✅ **Verification**: The change was verified by running the test suite (`uv run pytest`) and linters to confirm no regressions. Added a Sentinel Journal entry documenting the vulnerability and the `--` prevention pattern.

---
*PR created automatically by Jules for task [15504867156332047152](https://jules.google.com/task/15504867156332047152) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Security Fixes
- **[CRITICAL]** Fixed Command-Line Argument Injection vulnerability in macOS file metadata reading. The `CriteriaMatcher._get_macos_last_open` method now properly uses the `--` argument separator when invoking `xattr` to prevent file paths starting with `-` from being interpreted as command-line options (CWE-88).

### Changes Summary

| Category | Type | Details |
|----------|------|---------|
| Security | Fix | Added `--` separator in `xattr` subprocess call to prevent argument injection |
| Documentation | Update | Added critical security entry to Sentinel Journal documenting the vulnerability and prevention approach |

### Version
Updated to **0.0.75**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->