### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command-Line Argument Injection (CWE-88)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+## 2026-04-21 - [CRITICAL] Fix Command-Line Argument Injection (CWE-88) in xattr subprocess call
+
+**Vulnerability:** The application used `subprocess.run` to call `xattr` with a user-controlled file path without a `--` delimiter. If a file path started with a `-`, it could be interpreted as a command-line option flag, leading to potential command execution or unintended behavior (CWE-88).
+**Learning:** Command-line argument injection can occur when untrusted input is passed as arguments to subprocess calls, even if `shell=False` is used. This is particularly dangerous for commands that interpret options based on a leading `-`.
+**Prevention:** Always use the POSIX `--` delimiter when passing file paths or other user-controlled arguments to command-line utilities, especially if the arguments could start with a `-`.

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `subprocess.run` call for `xattr` in `app/services/criteria_matcher.py` passed the user-controlled `file_path` directly to the command line argument list without the POSIX `--` delimiter. If the `file_path` started with a `-`, it could be interpreted as an option flag by the `xattr` command (Command-Line Argument Injection, CWE-88).
🎯 Impact: This could allow an attacker to bypass intended operations, inject arbitrary options, or potentially cause command execution depending on the utility's behavior.
🔧 Fix: Added the `--` delimiter to the `subprocess.run` arguments before the `str(file_path)` argument. This forces all subsequent arguments to be treated as positional arguments (file paths) rather than options.
✅ Verification: Ran `uv run ruff check` and `SECRET_KEY=dummy_key uv run pytest tests/` to confirm that tests pass and the logic is sound.

---
*PR created automatically by Jules for task [978380268496907688](https://jules.google.com/task/978380268496907688) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Security Fix**: Resolved command-line argument injection vulnerability (CWE-88) in macOS extended attribute retrieval where user-controlled file paths could be interpreted as command-line options

| Component | Change | Type |
|-----------|--------|------|
| app/services/criteria_matcher.py | Added POSIX `--` delimiter in xattr subprocess call | Security Fix |
| .jules/sentinel.md | Documented CWE-88 vulnerability fix with prevention guidance | Documentation |
| VERSION | 0.0.84 | No change |

**Security Details**: The `xattr` command invocation now includes the `--` delimiter before the file path argument, ensuring paths beginning with `-` are correctly treated as positional operands rather than option flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->