### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection in subprocess.run

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,9 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+
+## 2026-04-10 - [HIGH] Fix Command-Line Argument Injection in subprocess.run
+
+**Vulnerability:** Calls to `subprocess.run` with utilities like `xattr` or `diskutil` passed user-controlled or variable file paths as arguments without the POSIX `--` delimiter or ensuring they were absolute paths. If a file path started with `-`, the command-line utility would parse it as a flag/option rather than a file path, potentially allowing an attacker to execute arbitrary options or cause application errors (CWE-88).
+**Learning:** Even when avoiding `shell=True` in `subprocess.run` (which prevents shell injection), you must still protect against Command-Line Argument/Option Injection. Utilities that parse flags from the command line can be tricked into interpreting a filename starting with `-` as a malicious option.
+**Prevention:** For utilities that support it, always insert `--` before the variable file path argument (e.g., `['xattr', '-p', 'name', '--', str(path)]`). For utilities that do not support `--` (like `diskutil`), convert the path to an absolute path (`str(path.absolute())`) so it always starts with `/`, preventing it from being parsed as a flag.

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,

--- a/app/utils/local_drive_identity.py
+++ b/app/utils/local_drive_identity.py
@@ -18,7 +18,7 @@ def _diskutil_info(path: Path) -> Dict:
         return {}
     try:
         proc = subprocess.run(
-            ["diskutil", "info", "-plist", str(path)],
+            ["diskutil", "info", "-plist", str(path.absolute())],
             check=True,
             capture_output=True,
             text=False,


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Command-Line Argument/Option Injection (CWE-88). Calls to `subprocess.run` with utilities like `xattr` or `diskutil` passed variable file paths as arguments without the POSIX `--` delimiter or ensuring they were absolute paths. If a file path started with `-`, the command-line utility would parse it as a flag/option rather than a file path.
🎯 **Impact:** Potential for an attacker to execute arbitrary options or cause application errors by providing a specially crafted filename (e.g., `-rf`).
🔧 **Fix:** For utilities that support it (`xattr`), inserted `--` before the variable file path argument to stop option parsing. For utilities that do not support `--` (`diskutil`), converted the path to an absolute path (`str(path.absolute())`) so it always starts with `/`, preventing it from being parsed as a flag.
✅ **Verification:** Ran `pytest` suite, `black` formatter, and `ruff` linter to ensure changes are correct and don't introduce regressions.

Added documentation to `.jules/sentinel.md` noting the vulnerability pattern and fix strategy.

---
*PR created automatically by Jules for task [14701118352207180626](https://jules.google.com/task/14701118352207180626) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **HIGH SEVERITY SECURITY FIX**: Fixed Command-Line Argument/Option Injection vulnerability (CWE-88) in subprocess calls to macOS utilities
- **xattr command**: Added POSIX `--` delimiter before file path argument to prevent filenames starting with `-` from being interpreted as command-line options
- **diskutil command**: Converted file path to absolute path (`path.absolute()`) to ensure paths always start with `/`, preventing flag injection
- **Documentation**: Updated `.jules/sentinel.md` with vulnerability description and fix strategy

## Updated Features

| Component | Change | Impact |
|-----------|--------|--------|
| `app/services/criteria_matcher.py` | Added `--` delimiter in xattr subprocess call | Prevents option injection through malicious filenames |
| `app/utils/local_drive_identity.py` | Convert diskutil path argument to absolute path | Prevents option injection through malicious filenames |
| `.jules/sentinel.md` | Added documentation entry for CWE-88 fix | Security documentation and prevention guidance |

## Version

Current version: **0.0.86**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->