### PR TITLE
build: add gcc and libgmp-dev to Dockerfile for build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM python:3.12-slim-bookworm AS builder
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libgmp-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 ENV UV_COMPILE_BYTECODE=1 \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added OS-level build dependencies (`gcc` and `libgmp-dev`) to the Docker builder stage to support compilation of Python packages with C extensions or mathematical library dependencies during the build process

## Changes

| Component | Status |
|-----------|--------|
| Docker build configuration | Updated |

**Note**: This is a build infrastructure improvement. No version bump is required. The VERSION file remains at 0.0.87.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->