### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+## 2024-05-11 - [HIGH] Command-Line Argument Injection via subprocess.run
+**Vulnerability:** Calls to `subprocess.run` (e.g., `xattr`, `diskutil`) used user-controlled or variable paths without preventing arguments from starting with `-`, potentially allowing command-line options injection if a file was named like `-rf`.
+**Learning:** Utilities lacking POSIX `--` delimiter support (like `diskutil`) require converting paths to absolute paths (`path.absolute()`) to guarantee the path starts with `/` and not `-`. Utilities that support `--` (like `xattr`) should use it.
+**Prevention:** Always use `--` for utilities that support it, or force absolute paths for utilities that don't, when executing `subprocess.run` with variable paths.

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,

--- a/app/utils/local_drive_identity.py
+++ b/app/utils/local_drive_identity.py
@@ -18,7 +18,7 @@ def _diskutil_info(path: Path) -> Dict:
         return {}
     try:
         proc = subprocess.run(
-            ["diskutil", "info", "-plist", str(path)],
+            ["diskutil", "info", "-plist", str(path.absolute())],
             check=True,
             capture_output=True,
             text=False,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection (CWE-88)

🚨 **Severity:** HIGH
💡 **Vulnerability:** Files with names starting with a hyphen (e.g., `-rf`) passed to command-line utilities via `subprocess.run` could be misinterpreted as command flags, potentially leading to command-line argument/option injection (CWE-88).
🎯 **Impact:** An attacker or malicious file could alter the behavior of `xattr` or `diskutil` execution, potentially leading to unexpected side-effects or security bypasses depending on the utility.
🔧 **Fix:** 
- Updated `xattr` call in `app/services/criteria_matcher.py` to use the standard POSIX `--` delimiter to enforce that subsequent arguments are treated as positional parameters (file paths).
- Updated `diskutil` call in `app/utils/local_drive_identity.py` to explicitly resolve the path to an absolute path (`path.absolute()`). Since `diskutil` does not support `--`, converting to absolute ensures the path string strictly starts with a `/` rather than a `-`.
✅ **Verification:** Verified via test suite (`pytest`) and linting/formatting checks (`black`, `ruff`). Code review was completed and approved.

---
*PR created automatically by Jules for task [1211284896512621735](https://jules.google.com/task/1211284896512621735) started by @martinoj2009*