### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command-Line Argument Injection in subprocess calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+
+## 2026-03-18 - [CRITICAL] Fix Command-Line Argument/Option Injection
+**Vulnerability:** The application executed `subprocess.run` with variable file paths without explicitly terminating command-line options. A file path beginning with a hyphen (`-`) could be misinterpreted as a command-line flag by commands like `xattr` or `diskutil`, potentially leading to argument injection or denial of service depending on the underlying tool.
+**Learning:** Even when avoiding shell execution (`shell=False`), argument injection is possible if user-provided or variable strings are interpreted as flags by the invoked command-line application.
+**Prevention:** Always use the POSIX double-dash `--` to signal the end of command options before providing variable arguments like file paths (e.g., `["xattr", "-p", "name", "--", filepath]`). For commands that do not support `--` (like macOS `diskutil`), convert file paths to absolute paths (`str(path.absolute())`) so they begin with a `/` rather than a `-`.

--- a/app/routers/api/files.py
+++ b/app/routers/api/files.py
@@ -756,9 +756,7 @@ def list_files(
 
             remote_rows = remote_query.all()
             aggregated_remote_rows: list[tuple[RemoteSharedFileCache, P2PPeer, list[str], int]] = []
-            grouped_remote_rows: dict[
-                tuple[str, str], dict[str, object]
-            ] = {}
+            grouped_remote_rows: dict[tuple[str, str], dict[str, object]] = {}
             for remote_file, peer in remote_rows:
                 dedupe_key = _build_remote_dedupe_key(remote_file)
                 existing_group = grouped_remote_rows.get(dedupe_key)
@@ -776,12 +774,9 @@ def list_files(
                     current_latest.last_announced_at if current_latest else None
                 )
                 remote_last_announced = remote_file.last_announced_at
-                if (
-                    remote_last_announced
-                    and (
-                        current_latest_announced is None
-                        or remote_last_announced > current_latest_announced
-                    )
+                if remote_last_announced and (
+                    current_latest_announced is None
+                    or remote_last_announced > current_latest_announced
                 ):
                     existing_group["remote_file"] = remote_file
                     existing_group["peer"] = peer
@@ -807,7 +802,10 @@ def list_files(
             }
             visible_remote_rows = []
             for remote_file, peer, peer_names, peer_count in aggregated_remote_rows:
-                if remote_file.checksum and str(remote_file.checksum).lower() in local_checksum_keys:
+                if (
+                    remote_file.checksum
+                    and str(remote_file.checksum).lower() in local_checksum_keys
+                ):
                     continue
                 visible_remote_rows.append((remote_file, peer, peer_names, peer_count))
 
@@ -864,13 +862,19 @@ def list_files(
                 for local_file in files_list:
                     local_peer_availability[local_file.id] = set()
                     if local_file.checksum:
-                        checksum_to_local_ids.setdefault(local_file.checksum, set()).add(local_file.id)
+                        checksum_to_local_ids.setdefault(local_file.checksum, set()).add(
+                            local_file.id
+                        )
                     if local_file.file_path:
-                        path_to_local_ids.setdefault(str(local_file.file_path), set()).add(local_file.id)
+                        path_to_local_ids.setdefault(str(local_file.file_path), set()).add(
+                            local_file.id
+                        )
 
                 match_clauses = []
                 if checksum_to_local_ids:
-                    match_clauses.append(RemoteSharedFileCache.checksum.in_(checksum_to_local_ids.keys()))
+                    match_clauses.append(
+                        RemoteSharedFileCache.checksum.in_(checksum_to_local_ids.keys())
+                    )
                 if path_to_local_ids:
                     match_clauses.extend(
                         [
@@ -894,7 +898,9 @@ def list_files(
                                 checksum_to_local_ids.get(remote_file.checksum, set())
                             )
                         if remote_file.file_path:
-                            matched_local_ids.update(path_to_local_ids.get(remote_file.file_path, set()))
+                            matched_local_ids.update(
+                                path_to_local_ids.get(remote_file.file_path, set())
+                            )
                         if remote_file.display_file_path:
                             matched_local_ids.update(
                                 path_to_local_ids.get(remote_file.display_file_path, set())
@@ -959,7 +965,9 @@ def list_files(
                     else:
                         network_peer_names = peer_names
                     effective_peer_names = network_peer_names if network_peer_names else peer_names
-                    effective_peer_count = len(effective_peer_names) if effective_peer_names else peer_count
+                    effective_peer_count = (
+                        len(effective_peer_names) if effective_peer_names else peer_count
+                    )
                     file_dict = _serialize_remote_cached_file(
                         remote_file,
                         peer,

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,

--- a/app/services/migrations.py
+++ b/app/services/migrations.py
@@ -14,9 +14,9 @@ from app.models import (
     FileTransactionHistory,
     MonitoredPath,
     P2PPeer,
-    RemoteSharedFileCache,
     RelocationTask,
     RelocationTaskStatus,
+    RemoteSharedFileCache,
     StorageType,
     TransactionType,
 )
@@ -235,7 +235,9 @@ def _serialize_p2p_sync_event(remote_file: RemoteSharedFileCache, peer: P2PPeer)
         "target_location_id": 0,
         "target_location_name": "Local P2P Cache",
         "status": "p2p_synced",
-        "created_at": (sync_time.isoformat() if sync_time else datetime.now(timezone.utc).isoformat()),
+        "created_at": (
+            sync_time.isoformat() if sync_time else datetime.now(timezone.utc).isoformat()
+        ),
         "started_at": None,
         "completed_at": sync_time.isoformat() if sync_time else None,
         "bytes_total": file_size,

--- a/app/services/p2p_service.py
+++ b/app/services/p2p_service.py
@@ -469,7 +469,9 @@ class P2PService:
 
             dest_path = os.path.join(local_path.source_path, filename)
             if os.path.exists(dest_path):
-                failed.append({"id": cache_id, "error": f"{filename} already exists in the destination path"})
+                failed.append(
+                    {"id": cache_id, "error": f"{filename} already exists in the destination path"}
+                )
                 continue
 
             encoded_id = quote(cache_entry.remote_file_id, safe="")

--- a/app/utils/local_drive_identity.py
+++ b/app/utils/local_drive_identity.py
@@ -18,7 +18,7 @@ def _diskutil_info(path: Path) -> Dict:
         return {}
     try:
         proc = subprocess.run(
-            ["diskutil", "info", "-plist", str(path)],
+            ["diskutil", "info", "-plist", str(path.absolute())],
             check=True,
             capture_output=True,
             text=False,


### PR DESCRIPTION
Fixed Command-Line Argument Injection vulnerability where a file path starting with a hyphen (`-`) could be interpreted as a flag by external tools invoked via `subprocess.run`.
Added the POSIX double-dash `--` for `xattr` calls and absolute paths for `diskutil` (which doesn't support `--`) to ensure paths are correctly treated as file arguments. 

Severity: CRITICAL
Vulnerability: Command-Line Argument/Option Injection
Impact: Potential for unexpected behavior, execution of arbitrary options, or Denial of Service by manipulating paths passed to `subprocess.run`.
Fix: Safely terminate the options argument stream.
Verification: Ran the test suite. All tests pass, formatters and linters report no issues.

---
*PR created automatically by Jules for task [12082392342399830710](https://jules.google.com/task/12082392342399830710) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EasyCloudDeploy/file-fridge/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->