### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+
+## 2026-05-17 - [HIGH] Fix Command Injection
+**Vulnerability:** Command-line argument injection where file paths starting with dashes could be parsed as command flags by subprocess calls.
+**Learning:** Tools invoked via `subprocess` can mistake arbitrary filenames (e.g., `-rf`) as command-line options. For POSIX-compliant tools like `xattr` or `mdls`, a double dash (`--`) halts option processing. For non-compliant tools like macOS `diskutil`, converting paths to absolute paths ensures they begin with a `/` rather than a `-`, avoiding option injection.
+**Prevention:** Always use the `--` delimiter for POSIX-compliant tools when passing variable file paths to subprocesses. For utilities that do not support `--`, convert the path to an absolute path to prevent it from being parsed as a flag.

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,

--- a/app/utils/local_drive_identity.py
+++ b/app/utils/local_drive_identity.py
@@ -18,7 +18,7 @@ def _diskutil_info(path: Path) -> Dict:
         return {}
     try:
         proc = subprocess.run(
-            ["diskutil", "info", "-plist", str(path)],
+            ["diskutil", "info", "-plist", str(path.absolute())],
             check=True,
             capture_output=True,
             text=False,


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Command-line argument injection where file paths starting with dashes could be parsed as command flags by subprocess calls.
* 🎯 Impact: Attackers might manipulate commands executed by the application if they can control filenames.
* 🔧 Fix: Used the `--` delimiter for POSIX-compliant tools (`xattr`) and converted paths to absolute for others (`diskutil`).
* ✅ Verification: Ran test suite and manually reviewed subprocess calls.

---
*PR created automatically by Jules for task [12839176084137119956](https://jules.google.com/task/12839176084137119956) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Security Fixes
- **[HIGH] Command Injection via File Path Arguments:** Fixed command-line argument injection vulnerability where file paths starting with dashes (`-`) could be interpreted as command flags by subprocess calls. Paths are now either prefixed with `--` (POSIX-compliant tools) or converted to absolute paths (non-POSIX tools).

### Changes Made

| Component | Change | Impact |
|-----------|--------|--------|
| `app/services/criteria_matcher.py` | Added `--` delimiter before file path in `xattr` subprocess call | Prevents interpretation of leading dashes as command flags |
| `app/utils/local_drive_identity.py` | Converted path to absolute form in `diskutil info` subprocess call | Prevents interpretation of relative paths containing dashes as flags |
| `.jules/sentinel.md` | Added security entry documenting command injection prevention | Security changelog updated with prevention guidance |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EasyCloudDeploy/file-fridge/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->