### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection in subprocess calls

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@
 **Vulnerability:** The tag creation endpoint (`/api/v1/tags`) returned an HTTP error detail containing unsanitized user input (`tag.name`) when attempting to create a duplicate tag, which could result in reflected/stored XSS and information disclosure.
 **Learning:** Any user input reflected in an API response, even within an error message or exception detail, can pose an injection or XSS risk. Input should not be echoed back to the user blindly.
 **Prevention:** Avoid reflecting user input in error messages. Log the event server-side with proper sanitization (e.g., using `sanitize_for_log`) while returning generic error messages to the client.
+## 2026-05-18 - [HIGH] Fix Command-Line Argument Injection
+**Vulnerability:** Subprocess calls to system utilities like `xattr` and `diskutil` included user-controlled paths without proper delimiters. This could allow an attacker to inject command-line arguments by crafting file paths that start with a hyphen (`-`), leading to unintended command execution.
+**Learning:** Even when using `subprocess.run` with a list of arguments (which prevents shell injection), argument injection is still possible if tools interpret paths starting with `-` as flags.
+**Prevention:** Always use the `--` delimiter before passing paths to tools that support POSIX options. For tools that do not support `--` (like `diskutil`), convert the path to an absolute path (`str(path.absolute())`) to ensure it always starts with a forward slash (`/`).

--- a/app/services/criteria_matcher.py
+++ b/app/services/criteria_matcher.py
@@ -361,7 +361,7 @@ class CriteriaMatcher:
 
             # Method 2: Try xattr (fallback)
             xattr_result = subprocess.run(
-                ["xattr", "-p", "com.apple.lastuseddate#PS", str(file_path)],
+                ["xattr", "-p", "com.apple.lastuseddate#PS", "--", str(file_path)],
                 check=False,
                 capture_output=True,
                 timeout=2,

--- a/app/utils/local_drive_identity.py
+++ b/app/utils/local_drive_identity.py
@@ -18,7 +18,7 @@ def _diskutil_info(path: Path) -> Dict:
         return {}
     try:
         proc = subprocess.run(
-            ["diskutil", "info", "-plist", str(path)],
+            ["diskutil", "info", "-plist", str(path.absolute())],
             check=True,
             capture_output=True,
             text=False,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Command-Line Argument Injection

🚨 Severity: HIGH
💡 Vulnerability: The `subprocess.run` calls for system utilities (`xattr`, `diskutil`) passed user-controlled paths without proper argument delimiters. If a malicious user crafted a file path starting with a hyphen (`-`), the utility would interpret it as a command-line flag rather than a positional argument.
🎯 Impact: This could allow an attacker to perform Command-Line Argument Injection, potentially leading to unauthorized operations or unintended utility behavior.
🔧 Fix: 
- For `xattr` (POSIX compliant), appended the `--` delimiter before passing the file path.
- For `diskutil` (non-POSIX compliant), used `.absolute()` to ensure the path always starts with a forward slash (`/`) and not a hyphen.
✅ Verification: Ran formatters, linters, and the full test suite (`pytest`) successfully. Added an entry to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [10983890974244806377](https://jules.google.com/task/10983890974244806377) started by @martinoj2009*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes v0.0.88

### Security Fixes

- **[HIGH] Command-Line Argument Injection in subprocess calls**: Fixed vulnerability in subprocess calls to system utilities (`xattr`, `diskutil`) that could allow argument injection when user-controlled file paths begin with a hyphen. Applied POSIX `--` delimiter before paths for `xattr`, and convert paths to absolute form for `diskutil` to ensure they always start with `/`.

### Updated Files

| Component | Type | Change |
|-----------|------|--------|
| `.jules/sentinel.md` | Documentation | Added security advisory for 2026-05-18 command-line argument injection fix |
| `app/services/criteria_matcher.py` | Bug Fix | Added `--` delimiter before file path in macOS `xattr` fallback call |
| `app/utils/local_drive_identity.py` | Bug Fix | Convert path to absolute form in macOS `diskutil info` subprocess call |

### Version Update

- **VERSION**: 0.0.87 → 0.0.88

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EasyCloudDeploy/file-fridge/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->